### PR TITLE
Add index field to JSON output

### DIFF
--- a/src/balance-tree.ts
+++ b/src/balance-tree.ts
@@ -46,8 +46,8 @@ export default class BalanceTree {
       index *= 2;
       let proofElement = proof[i];
 
-      if (computedHash.compare(proofElement) != 1) {
-        // computedHash <= proofElement
+      // computedHash <= proofElement
+      if (computedHash.compare(proofElement) !== 1) {
         computedHash = keccak256(Buffer.concat([computedHash, proofElement]));
       } else {
         computedHash = keccak256(Buffer.concat([proofElement, computedHash]));

--- a/src/parse-balance-map.ts
+++ b/src/parse-balance-map.ts
@@ -8,6 +8,7 @@ interface MerkleDistributorInfo {
   tokenTotal: string;
   claims: {
     [account: string]: {
+      index: number;
       amount: string;
       proof: string[];
     };
@@ -48,10 +49,11 @@ export function parseBalanceMap(balances: OldFormat): MerkleDistributorInfo {
 
   // generate claims
   const claims = sortedAddresses.reduce<{
-    [address: string]: {amount: string; proof: string[]};
-  }>((memo, address) => {
+    [address: string]: {index: number; amount: string; proof: string[]};
+  }>((memo, address, index) => {
     const {amount} = dataByAddress[address];
     memo[address] = {
+      index,
       amount: amount.toString(),
       proof: tree.getProof(address, amount),
     };

--- a/src/parse-balance-map.ts
+++ b/src/parse-balance-map.ts
@@ -50,10 +50,10 @@ export function parseBalanceMap(balances: OldFormat): MerkleDistributorInfo {
   // generate claims
   const claims = sortedAddresses.reduce<{
     [address: string]: {index: number; amount: string; proof: string[]};
-  }>((memo, address, index) => {
+  }>((memo, address) => {
     const {amount} = dataByAddress[address];
     memo[address] = {
-      index,
+      index: tree.getLeafIndex(address, amount),
       amount: amount.toString(),
       proof: tree.getProof(address, amount),
     };


### PR DESCRIPTION
The `index` field is required for checking if a user has claimed the airdrop via `isClaimed()`. Helps the UI to determine which amount to use and display: JSON amount or call `claimableBalance()`.