### PR TITLE
self-delegate on token claim

### DIFF
--- a/contracts/ArenaToken.sol
+++ b/contracts/ArenaToken.sol
@@ -96,6 +96,10 @@ contract ArenaToken is ERC20, ERC20Burnable, Ownable, ERC20Permit, ERC20Votes {
 
         // transfer claimable proportion to caller
         _transfer(address(this), msg.sender, claimableAmount);
+        // self-delegate if no prior delegatee was chosen
+        if (delegates(msg.sender) == address(0)) {
+            _delegate(msg.sender, msg.sender);
+        }
 
         require(address(tokenLock) != address(0), "Vesting contract not initialized");
         tokenLock.setupVesting(


### PR DESCRIPTION
# changelog
- we noticed that one starts out with zero voting power when claiming as OZ ERC20Votes does not default delegations to the token owner. This PR self-delegates to the token claimer if no prior delegatee was chosen.
- see [ERC20Votes._delegate](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v4.4/contracts/token/ERC20/extensions/ERC20Votes.sol#L209)
- fixes #34 